### PR TITLE
Fix/build file for linux

### DIFF
--- a/build.py
+++ b/build.py
@@ -58,6 +58,6 @@ if __name__ == "__main__":
             build_dependencies_for_windows()
 
     print("Usage: python build.py")
-    print(f"Available operating systems: linux, windows, not {platform.platform()}")
+    print(f"Available operating systems: linux, windows, not {platform}")
 
     sys.exit(1)

--- a/build.py
+++ b/build.py
@@ -6,7 +6,9 @@ import urllib.request
 import shutil
 
 if __name__ == "__main__":
-    HOME: str = os.environ["HOME"] if "Linux" in platform.platform() else os.environ["APPDATA"].replace("\\", "/")
+    platform = platform.platform()
+
+    HOME: str = os.environ["HOME"] if "Linux" in platform else os.environ["APPDATA"].replace("\\", "/")
 
     os.makedirs(f"{HOME}/thrushlang/backends/llvm/build", exist_ok= True)
 
@@ -50,10 +52,10 @@ if __name__ == "__main__":
 
         sys.exit(0)
     
-    match platform.platform():
-
-        case "Linux": build_dependencies_for_linux()
-        case "Windows": build_dependencies_for_windows()
+        if "Linux" in platform:
+            build_dependencies_for_linux()
+        if "Windows" in platform:
+            build_dependencies_for_windows()
 
     print("Usage: python build.py")
     print(f"Available operating systems: linux, windows, not {platform.platform()}")

--- a/build.py
+++ b/build.py
@@ -6,8 +6,9 @@ import urllib.request
 import shutil
 
 if __name__ == "__main__":
+    print(platform.platform())
 
-    HOME: str = os.environ["HOME"] if platform.platform() == "Linux" else os.environ["APPDATA"].replace("\\", "/")
+    HOME: str = os.environ["HOME"] if "Linux" in platform.platform() else os.environ["APPDATA"].replace("\\", "/")
 
     os.makedirs(f"{HOME}/thrushlang/backends/llvm/build", exist_ok= True)
 

--- a/build.py
+++ b/build.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     elif "windows" in PLATFORM:
         build_dependencies_for_windows()
 
-    print("Usage: python build.py")
+    print(f"Usage: {"py" if "windows" in PLATFORM else "python3"} {sys.argv[0]}")
     print(f"Available operating systems: linux, windows, not {PLATFORM}")
 
     sys.exit(1)

--- a/build.py
+++ b/build.py
@@ -1,7 +1,6 @@
 import platform
 import sys
 import os
-import platform
 import urllib.request
 import shutil
 

--- a/build.py
+++ b/build.py
@@ -6,9 +6,9 @@ import urllib.request
 import shutil
 
 if __name__ == "__main__":
-    platform = (platform.platform()).lower()
+    PLATFORM: str = (platform.platform()).lower()
 
-    HOME: str = os.environ["HOME"] if "linux" in platform else os.environ["APPDATA"].replace("\\", "/")
+    HOME: str = os.environ["HOME"] if "linux" in PLATFORM else os.environ["APPDATA"].replace("\\", "/")
 
     os.makedirs(f"{HOME}/thrushlang/backends/llvm/build", exist_ok= True)
 
@@ -52,12 +52,12 @@ if __name__ == "__main__":
 
         sys.exit(0)
 
-    if "linux" in platform:
+    if "linux" in PLATFORM:
         build_dependencies_for_linux()
-    elif "windows" in platform:
+    elif "windows" in PLATFORM:
         build_dependencies_for_windows()
 
     print("Usage: python build.py")
-    print(f"Available operating systems: linux, windows, not {platform}")
+    print(f"Available operating systems: linux, windows, not {PLATFORM}")
 
     sys.exit(1)

--- a/build.py
+++ b/build.py
@@ -6,8 +6,6 @@ import urllib.request
 import shutil
 
 if __name__ == "__main__":
-    print(platform.platform())
-
     HOME: str = os.environ["HOME"] if "Linux" in platform.platform() else os.environ["APPDATA"].replace("\\", "/")
 
     os.makedirs(f"{HOME}/thrushlang/backends/llvm/build", exist_ok= True)

--- a/build.py
+++ b/build.py
@@ -6,9 +6,9 @@ import urllib.request
 import shutil
 
 if __name__ == "__main__":
-    platform = platform.platform()
+    platform = (platform.platform()).lower()
 
-    HOME: str = os.environ["HOME"] if "Linux" in platform else os.environ["APPDATA"].replace("\\", "/")
+    HOME: str = os.environ["HOME"] if "linux" in platform else os.environ["APPDATA"].replace("\\", "/")
 
     os.makedirs(f"{HOME}/thrushlang/backends/llvm/build", exist_ok= True)
 
@@ -51,11 +51,11 @@ if __name__ == "__main__":
         print("Dependencies are ready to compile. Use 'cargo clean' and 'cargo run' now.")
 
         sys.exit(0)
-    
-        if "Linux" in platform:
-            build_dependencies_for_linux()
-        if "Windows" in platform:
-            build_dependencies_for_windows()
+
+    if "linux" in platform:
+        build_dependencies_for_linux()
+    elif "windows" in platform:
+        build_dependencies_for_windows()
 
     print("Usage: python build.py")
     print(f"Available operating systems: linux, windows, not {platform}")

--- a/build.py
+++ b/build.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     elif "windows" in PLATFORM:
         build_dependencies_for_windows()
 
-    print(f"Usage: {"py" if "windows" in PLATFORM else "python3"} {sys.argv[0]}")
+    print(f"Usage: {"py" if "windows" in PLATFORM else "python3"} {' '.join(sys.argv)}")
     print(f"Available operating systems: linux, windows, not {PLATFORM}")
 
     sys.exit(1)


### PR DESCRIPTION
Antes, no detectaba los sistemas operativos que usan Linux, ya que se comparaban las cadenas de texto, y la función `platform` también retornaba la versión, el tipo, etc.  
Ahora se evalúa si la cadena `'linux'` está presente en el valor retornado por la función `platform`.

Además, se almacena el resultado en una variable para evitar ejecutar la función múltiples veces.

También se eliminó el import repetido de `platform`.