### PR TITLE
Fix/build file for linux

### DIFF
--- a/build.py
+++ b/build.py
@@ -18,15 +18,16 @@ if __name__ == "__main__":
         GITHUB_BUILD_FILE: str = f"https://github.com/thrushlang/toolchains/releases/download/LLVM-C/{COMPRESS_FILE}"
         TEMP_BUILD_DIR: str = "thrushc-build"
         TEMP_BUILD_PATH: str = os.path.join(TEMP_BUILD_DIR, "thrushc-llvm-linux-x64-v1.0.0.tar.gz")
+        TEMP_LLVM_DIR: str = os.path.abspath('llvm/')
 
         print("Building dependencies for The Thrush Compiler in Linux...")
 
         os.makedirs(TEMP_BUILD_DIR, exist_ok=True)
-        os.makedirs(os.path.abspath('llvm/'), exist_ok=True)
+        os.makedirs(TEMP_LLVM_DIR, exist_ok=True)
 
         wget: int = os.system(f"wget {GITHUB_BUILD_FILE} -O {TEMP_BUILD_PATH} -o /dev/null")
         tar: int = os.system(f"tar xvf {TEMP_BUILD_PATH} > /dev/null")
-        decompress: int = os.system(f"rsync -r -a -mkpath {os.path.abspath('llvm/')} {FINAL_BUILD_PATH}")
+        decompress: int = os.system(f"rsync -r -a -mkpath {TEMP_LLVM_DIR} {FINAL_BUILD_PATH}")
 
         for action in [wget, tar, decompress]:
             if action != 0:
@@ -34,6 +35,7 @@ if __name__ == "__main__":
                 sys.exit(1)
 
         shutil.rmtree(TEMP_BUILD_DIR, ignore_errors= True)
+        # shutil.rmtree(TEMP_LLVM_DIR, ignore_errors= True) No estoy seguro si se requiere este directorio o no
 
         print("Dependencies are ready to compile. Use 'cargo clean' and 'cargo run' now.")
 

--- a/build.py
+++ b/build.py
@@ -9,33 +9,31 @@ if __name__ == "__main__":
 
     HOME: str = os.environ["HOME"] if SYSTEM == "linux" else os.environ["APPDATA"].replace("\\", "/")
 
-    BUILD_PATH: str = os.path.join(HOME, "thrushlang", "backends", "llvm", "build")
+    FINAL_BUILD_PATH: str = os.path.join(HOME, "thrushlang", "backends", "llvm", "build")
 
-    os.makedirs(BUILD_PATH, exist_ok= True)
+    os.makedirs(FINAL_BUILD_PATH, exist_ok= True)
 
     def build_dependencies_for_linux():
         COMPRESS_FILE: str = "thrushc-llvm-linux-x64-v1.0.0.tar.gz"
         GITHUB_BUILD_FILE: str = f"https://github.com/thrushlang/toolchains/releases/download/LLVM-C/{COMPRESS_FILE}"
-
-        if os.path.exists(COMPRESS_FILE):
-            print(f"{COMPRESS_FILE} already exists. Deleting...")
-            os.remove(COMPRESS_FILE)
+        TEMP_BUILD_DIR: str = "thrushc-build"
+        TEMP_BUILD_PATH: str = os.path.join(TEMP_BUILD_DIR, "thrushc-llvm-linux-x64-v1.0.0.tar.gz")
 
         print("Building dependencies for The Thrush Compiler in Linux...")
 
-        os.makedirs("thrushc-build", exist_ok=True)
+        os.makedirs(TEMP_BUILD_DIR, exist_ok=True)
         os.makedirs(os.path.abspath('llvm/'), exist_ok=True)
 
-        wget: int = os.system(f"wget {GITHUB_BUILD_FILE} -O {os.path.join('thrushc-build', COMPRESS_FILE)} -o /dev/null")
-        gunzip: int = os.system(f"gunzip -c {os.path.join('thrushc-build', COMPRESS_FILE)} > {os.path.join('thrushc-build', 'llvm.tar')}")
-        decompress: int = os.system(f"tar -xvf thrushc-build/llvm.tar -C {BUILD_PATH}")
+        wget: int = os.system(f"wget {GITHUB_BUILD_FILE} -O {TEMP_BUILD_PATH} -o /dev/null")
+        tar: int = os.system(f"tar xvf {TEMP_BUILD_PATH} > /dev/null")
+        decompress: int = os.system(f"rsync -r -a -mkpath {os.path.abspath('llvm/')} {FINAL_BUILD_PATH}")
 
-        for action in [wget, gunzip, decompress]:
+        for action in [wget, tar, decompress]:
             if action != 0:
                 print(f"Error in {action}")
                 sys.exit(1)
 
-        shutil.rmtree("thrushc-build/", ignore_errors= True)
+        shutil.rmtree(TEMP_BUILD_DIR, ignore_errors= True)
 
         print("Dependencies are ready to compile. Use 'cargo clean' and 'cargo run' now.")
 

--- a/build.py
+++ b/build.py
@@ -6,29 +6,39 @@ import shutil
 
 if __name__ == "__main__":
     SYSTEM: str = platform.system().lower()
-    
+
     HOME: str = os.environ["HOME"] if SYSTEM == "linux" else os.environ["APPDATA"].replace("\\", "/")
 
-    os.makedirs(f"{HOME}/thrushlang/backends/llvm/build", exist_ok= True)
+    BUILD_PATH: str = os.path.join(HOME, "thrushlang", "backends", "llvm", "build")
 
-    def build_dependencies_for_linux(): 
+    os.makedirs(BUILD_PATH, exist_ok= True)
+
+    def build_dependencies_for_linux():
+        COMPRESS_FILE: str = "thrushc-llvm-linux-x64-v1.0.0.tar.gz"
+        GITHUB_BUILD_FILE: str = f"https://github.com/thrushlang/toolchains/releases/download/LLVM-C/{COMPRESS_FILE}"
+
+        if os.path.exists(COMPRESS_FILE):
+            print(f"{COMPRESS_FILE} already exists. Deleting...")
+            os.remove(COMPRESS_FILE)
 
         print("Building dependencies for The Thrush Compiler in Linux...")
 
-        if not os.path.exists("thrushc-build"): os.mkdir("thrushc-build")
+        os.makedirs("thrushc-build", exist_ok=True)
+        os.makedirs(os.path.abspath('llvm/'), exist_ok=True)
 
-        wget: int = os.system("wget https://github.com/thrushlang/toolchains/releases/download/LLVM-C/thrushc-llvm-linux-x64-v1.0.0.tar.gz -o thrushc-build/thrushc-llvm-linux-x64-v1.0.0.tar.gz")
-        tar: int = os.system("tar xvf thrushc-build/thrushc-llvm-linux-x64-v1.0.0.tar.gz")
-        decompress: int = os.system(f"rsync -r -a -mkpath {os.path.abspath("llvm/")} {HOME}//thrushlang/backends/llvm/build")
+        wget: int = os.system(f"wget {GITHUB_BUILD_FILE} -O {os.path.join('thrushc-build', COMPRESS_FILE)} -o /dev/null")
+        gunzip: int = os.system(f"gunzip -c {os.path.join('thrushc-build', COMPRESS_FILE)} > {os.path.join('thrushc-build', 'llvm.tar')}")
+        decompress: int = os.system(f"tar -xvf thrushc-build/llvm.tar -C {BUILD_PATH}")
 
-        if sum([wget, tar, decompress]) > 0:
-            print("Failed to install LLVM-C API.")
-            sys.exit(1)
+        for action in [wget, gunzip, decompress]:
+            if action != 0:
+                print(f"Error in {action}")
+                sys.exit(1)
 
         shutil.rmtree("thrushc-build/", ignore_errors= True)
 
         print("Dependencies are ready to compile. Use 'cargo clean' and 'cargo run' now.")
-        
+
         sys.exit(0)
 
     def build_dependencies_for_windows():
@@ -39,7 +49,7 @@ if __name__ == "__main__":
 
         urllib.request.urlretrieve("https://github.com/thrushlang/toolchains/releases/download/LLVM-C/thrushc-llvm-windows-x64-v1.0.0.tar.xz", "thrushc-build/thrushc-llvm-windows-x64-v1.0.0.tar.xz")
 
-        tar: int = os.system(f"tar -xJf thrushc-build/thrushc-llvm-windows-x64-v1.0.0.tar.xz -C {HOME}/thrushlang/backends/llvm/build/") 
+        tar: int = os.system(f"tar -xJf thrushc-build/thrushc-llvm-windows-x64-v1.0.0.tar.xz -C {HOME}/thrushlang/backends/llvm/build/")
 
         if tar > 0:
             print("Failed to install the LLVM-C API.")
@@ -54,7 +64,7 @@ if __name__ == "__main__":
     match SYSTEM:
         case "linux":
             build_dependencies_for_linux()
-        case "windows": 
+        case "windows":
             build_dependencies_for_windows()
 
     print(f"Usage: {"py" if SYSTEM == "windows" else "python3"}")


### PR DESCRIPTION
Se arregla el siguiente error:
```bash
gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
Failed to install LLVM-C API.
```

Esto sucedía porque al usar el programa `wget`, se usaba la flag `-o`, la cual se utiliza para redirigir los logs. Como resultado, el archivo descargado en el directorio temporal del build solo contenía los logs, y al intentar descomprimirlo, no se podía.

Ahora, se cambió por la flag `-O`, que permite guardar el archivo en otra ubicación con un nombre distinto. Además, se combinó con la flag `-o` para evitar mostrar los logs directamente.

También, se refactorizó el código para mejorar su mantenibilidad.

Algunos cambios de espacios, es por mi Prettier XD.

Por último, se agrega `path.join`, ya que actúa dinámicamente entre `/` para Unix y `\` para Windows.