### PR TITLE
FixIncorrectTypes

### DIFF
--- a/build.py
+++ b/build.py
@@ -36,9 +36,9 @@ if __name__ == "__main__":
             
             return response_json
         
-    def get_llvm_c_apis(github_api_releases: Dict[str, Any]) -> Dict[str, Any]:
+    def get_llvm_c_apis(github_api_releases: Dict[str, Any]) -> List[Dict[str, Any]]:
 
-        llvm_c_apis: List[Dict[str, Any]] = [llvm_c_api for llvm_c_api in github_api_releases if llvm_c_api["tag_name"] == "LLVM-C"]
+        llvm_c_apis: List[Dict[str, Any]] = [llvm_c_api for llvm_c_api in github_api_releases if isinstance(llvm_c_api, dict) and llvm_c_api.get("tag_name") == "LLVM-C"]
 
         if len(llvm_c_apis) == 0:
 


### PR DESCRIPTION
Se realiza el **arreglo de los tipos** que retorna `get_llvm_c_apis`, ya que:

- La función `get_llvm_c_api` debía recibir como argumento un valor de tipo `tuple[str, str]`.
- La variable `llvm_c_apis` estaba retornando un `List[str]`, cuando en realidad debía ser `List[Dict[str, Any]]`.

Estos cambios aseguran una mejor coherencia en los tipos y evitan errores de interpretación o ejecución en tiempo de desarrollo.